### PR TITLE
Changed the wording around git hosting options which had a callout to

### DIFF
--- a/docs/notebooks/01_intro.html
+++ b/docs/notebooks/01_intro.html
@@ -233,6 +233,8 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
   <ul class="collapse">
   <li><a href="#questions" id="toc-questions" class="nav-link" data-scroll-target="#questions">Questions</a></li>
   <li><a href="#objectives" id="toc-objectives" class="nav-link" data-scroll-target="#objectives">Objectives</a></li>
+  <li><a href="#what-well-cover-in-this-workshop" id="toc-what-well-cover-in-this-workshop" class="nav-link" data-scroll-target="#what-well-cover-in-this-workshop">What we’ll cover in this workshop</a></li>
+  <li><a href="#what-is-version-control" id="toc-what-is-version-control" class="nav-link" data-scroll-target="#what-is-version-control">What is version control?</a></li>
   <li><a href="#version-control-systems" id="toc-version-control-systems" class="nav-link" data-scroll-target="#version-control-systems">Version control systems</a></li>
   <li><a href="#the-long-history-of-version-control-systems" id="toc-the-long-history-of-version-control-systems" class="nav-link" data-scroll-target="#the-long-history-of-version-control-systems">The Long History of Version Control Systems</a>
   <ul class="collapse">
@@ -262,6 +264,16 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <li>Understand the basics of how automated version control systems work.</li>
 </ul>
 </section>
+<section id="what-well-cover-in-this-workshop" class="level2">
+<h2 class="anchored" data-anchor-id="what-well-cover-in-this-workshop">What we’ll cover in this workshop</h2>
+<p>This workshop will introduce you to Git and show you how it can be used at a couple of different levels.</p>
+<p>In the first sections we’ll create a local git repository, and use it to keep track of changes to a very simple Python program.</p>
+<p>We’ll then learn how to push code from our local repository to GitHub, and how GitHub can be used to share your code with a collaborator.</p>
+<p>In the third section, we’ll learn about branches, and how they can be used to maintain different versions of the same code, and help to organise your team’s software development.</p>
+<p>And in the final section, we’ll show you how to fork a repository and create a pull request, which is how Git and GitHub are used to manage contributions to open source software projects, and hopefully also cover some best practices for open research with Git.</p>
+</section>
+<section id="what-is-version-control" class="level2">
+<h2 class="anchored" data-anchor-id="what-is-version-control">What is version control?</h2>
 <p>We’ll start by exploring how version control can be used to keep track of what one person did and when. Even if you aren’t collaborating with other people, automated version control is much better than this situation:</p>
 <div class="quarto-figure quarto-figure-center">
 <figure class="figure">
@@ -301,6 +313,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p></p><figcaption class="figure-caption">Multiple Versions Can be Merged</figcaption><p></p>
 </figure>
 </div>
+</section>
 <section id="version-control-systems" class="level2">
 <h2 class="anchored" data-anchor-id="version-control-systems">Version control systems</h2>
 <p>A <strong>version control system</strong> is a tool that keeps track of these changes for us, effectively creating different versions of our files. It allows us to decide which changes will be made to the next version (each record of these changes is called a <strong>commit</strong>, and keeps useful metadata about them. The complete history of commits for a particular project and their metadata make up a <strong>repository</strong>. Repositories can be kept in sync across different computers, facilitating collaboration among different people.</p>
@@ -313,8 +326,9 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <section id="key-points" class="level3 keypoints">
 <h3 class="anchored" data-anchor-id="key-points">Key points</h3>
 <ul>
-<li>Version control is like an unlimited ‘undo’ (kind of, and not always).</li>
-<li>Version control also allows many people to work in parallel.</li>
+<li>Version control is like an unlimited ‘undo’ (kind of, and not always)</li>
+<li>Version control allows members of a team to work in parallel</li>
+<li>Version control systems like GitHub are how people contribute to open source software</li>
 </ul>
 </section>
 

--- a/docs/notebooks/04_changes.html
+++ b/docs/notebooks/04_changes.html
@@ -547,7 +547,7 @@ Directories
 <p>To recap, when we want to add changes to our repository, we first need to add the changed files to the staging area (<code>git add</code>) and then commit the staged changes to the repository (<code>git commit</code>):</p>
 <div class="quarto-figure quarto-figure-center">
 <figure class="figure">
-<p><img src="https://swcarpentry.github.io/git-novice/fig/git-committing.svg" class="img-fluid figure-img"></p>
+<p><img src="../fig/git-committing.svg" class="img-fluid figure-img"></p>
 <p></p><figcaption class="figure-caption">The Git Commit Workflow</figcaption><p></p>
 </figure>
 </div>

--- a/docs/notebooks/07_github.html
+++ b/docs/notebooks/07_github.html
@@ -273,7 +273,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 </ul>
 </section>
 <p>Version control really comes into its own when we begin to collaborate with other people. We already have most of the machinery we need to do this; the only thing missing is to copy changes from one repository to another.</p>
-<p>Systems like Git allow us to move work between any two repositories. In practice, though, it’s easiest to use one copy as a central hub, and to keep it on the web rather than on someone’s laptop. Most programmers use hosting services like <a href="https://github.com">GitHub</a>, <a href="https://bitbucket.org">Bitbucket</a> or <a href="https://gitlab.com/">GitLab</a> to hold those main copies; we’ll explore the pros and cons of this in a later episode.</p>
+<p>Systems like Git allow us to move work between any two repositories. In practice, though, it’s easiest to use one copy as a central hub, and to keep it on the web rather than on someone’s laptop. Most programmers use hosting services like <a href="https://github.com">GitHub</a>, <a href="https://bitbucket.org">Bitbucket</a> or <a href="https://gitlab.com/">GitLab</a> to hold those main copies. Your institution may also have its own hosted GitHub or GitLab instance. Where you host research software can depend on whether you want it to be public or private, and on what options are available to research staff or students.</p>
 <p>Let’s start by sharing the changes we’ve made to our current project with the world. To this end we are going to create a <em>remote</em> repository that will be linked to our <em>local</em> repository.</p>
 <section id="create-a-remote-repository" class="level2">
 <h2 class="anchored" data-anchor-id="create-a-remote-repository">1. Create a remote repository</h2>
@@ -339,7 +339,7 @@ HTTPS vs.&nbsp;SSH
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p>We use SSH here because, while it requires some additional configuration, it is a security protocol widely used by many applications. The steps below describe SSH at a minimum level for GitHub. A supplemental episode to this lesson discusses advanced setup and concepts of SSH and key pairs, and other material supplemental to git related SSH.</p>
+<p>We use SSH here because, while it requires some additional configuration, it is a security protocol widely used by many applications. The steps below describe SSH at a minimum level for GitHub.</p>
 </div>
 </div>
 <div class="quarto-figure quarto-figure-center">
@@ -365,21 +365,6 @@ HTTPS vs.&nbsp;SSH
 <p>SSH uses what is called a key pair. This is two keys that work together to validate access. One key is publicly known and called the public key, and the other key called the private key is kept private. Very descriptive names.</p>
 <p>You can think of the public key as a padlock, and only you have the key (the private key) to open it. You use the public key where you want a secure method of communication, such as your GitHub account. You give this padlock, or public key, to GitHub and say “lock the communications to my account with this so that only computers that have my private key can unlock communications and send git commands as my GitHub account.”</p>
 <p>What we will do now is the minimum required to set up the SSH keys and add the public key to a GitHub account.</p>
-<div class="callout callout callout-style-simple no-icon callout-captioned">
-<div class="callout-header d-flex align-content-center">
-<div class="callout-icon-container">
-<i class="callout-icon no-icon"></i>
-</div>
-<div class="callout-caption-container flex-fill">
-Advanced SSH
-</div>
-</div>
-<div class="callout-body-container callout-body">
-<ul>
-<li>A supplemental episode in this lesson discusses SSH and key pairs in more depth and detail.</li>
-</ul>
-</div>
-</div>
 <p>The first thing we are going to do is check if this has already been done on the computer you’re on. Because generally speaking, this setup only needs to happen once and then you can forget about it.</p>
 <div class="callout callout callout-style-simple no-icon callout-captioned">
 <div class="callout-header d-flex align-content-center">
@@ -465,7 +450,7 @@ Keeping your keys secure
 <h2 class="anchored" data-anchor-id="push-local-changes-to-a-remote">4. Push local changes to a remote</h2>
 <p>Now that authentication is setup, we can return to the remote. This command will push the changes from our local repository to the repository on GitHub:</p>
 <div class="sourceCode" id="cb21"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> push origin main</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<p>Since Alice set up a passphrase, it will prompt her for it. If you completed advanced settings for your authentication, it will not prompt for a passphrase.</p>
+<p>Since Alice set up a passphrase, it will prompt her for it.</p>
 <div class="sourceCode" id="cb22"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a>Enumerating objects<span class="ch">:</span> 16, done.</span>
 <span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>Counting objects<span class="ch">:</span> 100<span class="co">% (16/16), done.</span></span>
 <span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>Delta compression using up to 8 threads.</span>

--- a/docs/notebooks/11_workflows.html
+++ b/docs/notebooks/11_workflows.html
@@ -261,19 +261,15 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <li>Understand how and when to delete branches without losing history</li>
 </ul>
 </section>
-<section id="key-points" class="level3 keypoints">
-<h3 class="anchored" data-anchor-id="key-points">Key Points</h3>
-<ul>
-<li>Creating a branch is a cheap, fast operation</li>
-<li>Branch-based workflows are a good way for an individual or team to organise their repository</li>
-<li>You can pick a naming convention which best suits your needs</li>
-<li>Once a branch is merged, it can be safely deleted</li>
-</ul>
-</section>
 <p>We’ve just seen an example of creating a branch to do some development work, and merging the changes back to the main branch.</p>
 <p>Our repository only has a few files, but if we were working on a repository with dozens or hundreds of files, creating a branch may seem like it’s inefficient, especially if the change we’re working on only affects one or two files.</p>
 <p>However, git is designed for working efficiently with large codebases. When you create a branch, internally, git isn’t creating another copy of your entire repository. Instead, it’s storing a reference to the HEAD of the branch which you’re starting from, and saying - here’s a new branch which starts at this commit.</p>
-<p>[ a diagram showing how a branch starts ]</p>
+<div class="quarto-figure quarto-figure-center">
+<figure class="figure">
+<p><img src="../fig/workflow_branch.svg" class="img-fluid figure-img"></p>
+<p></p><figcaption class="figure-caption">A diagram showing how a branch starts</figcaption><p></p>
+</figure>
+</div>
 <p>So, internally, a new branch isn’t really a “copy” of anything, it’s a reference to a new set of commits. You will only add new content to the repository when you add some new changes as a new commit, and the only extra content which your branch needs is the difference those changes represent.</p>
 <p>This is why you’ll see people saying things like “branches are free” or “branches are cheap” in Git, and it’s one of the differences between Git and older version control systems, where a branch really did equal a copy of your entire codebase.</p>
 <p>It also gives us a guiding principal for how to branch our code. In general, small branches are better - ideally, restricted to one feature or bugfix.</p>
@@ -321,6 +317,15 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <div class="sourceCode" id="cb15"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a>error<span class="ch">:</span> the branch 'just-testing' is not fully merged.</span>
 <span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>If you are sure you want to delete it, run 'git branch -D just-testing'</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <p>If we’re sure that this branch isn’t worth keeping, the capital <code>-D</code> flag will get rid of it.</p>
+<section id="key-points" class="level3 keypoints">
+<h3 class="anchored" data-anchor-id="key-points">Key Points</h3>
+<ul>
+<li>Creating a branch is a cheap, fast operation</li>
+<li>Branch-based workflows are a good way for an individual or team to organise their repository</li>
+<li>You can pick a naming convention which best suits your needs</li>
+<li>Once a branch is merged, it can be safely deleted</li>
+</ul>
+</section>
 
 
 </section>

--- a/docs/notebooks/12_conflicts.html
+++ b/docs/notebooks/12_conflicts.html
@@ -334,12 +334,13 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 </figure>
 </div>
 <p>Git rejects the push because it detects that the remote repository has new updates that have not been incorporated into the local branch. What we have to do is pull the changes from GitHub.</p>
-<p>Now we come to some exciting, or exasperating, developments: Git is an actively developed piece of open-source software. Over the last couple of years, there have been some changes to the way Git handles the situation we’re about to trigger, and depending on when you installed Git, we might get some different sorts of behaviour at the command line. I’ll have to go into a little bit of detail to explain what’s happening, even though the net result will be the same.</p>
+<p>Now we come to some exciting, or exasperating, developments: Git is an actively developed piece of open-source software. Over the last couple of years, there have been some changes to the way Git handles the situation we’re about to trigger, and depending on when you installed Git, we might get some different sorts of behaviour at the command line.</p>
+<p>I’ll have to go into a little bit of detail to explain what’s happening, even though the net result will be the same.</p>
 <p>What we’re going to use is the <code>git pull</code> command. This asks Git to do two things: fetch the HEAD of the branch we’re interested in from a remote repository, giving us a local copy of the latest version from the remote. We then want Git to <code>merge</code> that set of changes into our current branch.</p>
 <p>We’ve set up a situation, however, where Bob and Alice’s version of the file are inconsistent, in a way which <code>merge</code> is unable to resolve.</p>
 <p>Let’s see what happens, and I’ll see what messages we’re getting, and step through the explanations.</p>
 <div class="sourceCode" id="cb15"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> pull origin main</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<p>If Bob has a recent version of Git (newer than July, 2021), pulling from Alice’s remote should result in a long message like the following, ending in a fatal error:</p>
+<p>If Bob has a recent version of Git (2.33 or newer), pulling from Alice’s remote should result in a long message like the following, ending in a fatal error:</p>
 <div class="sourceCode" id="cb16"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Enumerating objects<span class="ch">:</span> 20, done.</span>
 <span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Counting objects<span class="ch">:</span> 100<span class="co">% (20/20), done.</span></span>
 <span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Compressing objects<span class="ch">:</span> 100<span class="co">% (9/9), done.</span></span>
@@ -400,8 +401,8 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>Auto-merging mean.py</span>
 <span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a>CONFLICT <span class="dt">(</span>content<span class="dt">)</span><span class="ch">:</span> Merge conflict in mean.py</span>
 <span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a>Automatic merge failed; fix conflicts and then commit the result.</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<p>This is the original (pre-2020) <code>git pull</code> behaviour, when it used to merge by default. If this happened to you, git has fetched Alice’s copy and tried, and failed, to merge it with the local changes</p>
-<p>The third possibility is for people with a copy of Git from 2020 to 2021: this gives the long set of warnings about needing to specify a reconciliation strategy, but defaults to <code>merge</code> anyway, and should look something like this:</p>
+<p>This is how <code>git pull</code> behaved before version 2.27, when it used to merge by default and not warn you about it. If this happened to you, git has fetched Alice’s copy and tried, and failed, to merge it with the local changes.</p>
+<p>The third possibility is for people with a copy of Git with a version between 2.27 and 2.33: this gives the long set of warnings about needing to specify a reconciliation strategy, but defaults to <code>merge</code> anyway, and should look something like this:</p>
 <div class="sourceCode" id="cb20"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Enumerating objects<span class="ch">:</span> 20, done.</span>
 <span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Counting objects<span class="ch">:</span> 100<span class="co">% (20/20), done.</span></span>
 <span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Compressing objects<span class="ch">:</span> 100<span class="co">% (9/9), done.</span></span>
@@ -425,80 +426,83 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <span id="cb20-21"><a href="#cb20-21" aria-hidden="true" tabindex="-1"></a>Auto-merging mean.py</span>
 <span id="cb20-22"><a href="#cb20-22" aria-hidden="true" tabindex="-1"></a>CONFLICT <span class="dt">(</span>content<span class="dt">)</span><span class="ch">:</span> Merge conflict in mean.py</span>
 <span id="cb20-23"><a href="#cb20-23" aria-hidden="true" tabindex="-1"></a>Automatic merge failed; fix conflicts and then commit the result.</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>You can check which version of Git you have installed by running this command:</p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> <span class="at">--version</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb22"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a>git version 2.37.0 <span class="dt">(</span>Apple Git-136<span class="dt">)</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <p>Let’s just go around the room and check that everyone has a big CAPS-LOCK message saying CONFLICT (usually you don’t look for conflict in this kind of workshop, but it’s git.)</p>
 <p>So now that we’re all on the same page. Git has tried to merge changes from the remote branch, and has detected that changes made to the local copy overlap with those made to the remote repository, and therefore refuses to merge the two versions to stop us from trampling on our previous work. The conflict is marked in in the affected file:</p>
-<div class="sourceCode" id="cb21"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cat mean.py</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<div class="sourceCode" id="cb22"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a>import pandas as pd</span>
-<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD</span>
-<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>COLOUR=<span class="st">"red"</span></span>
-<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>dataframe = pd.read_csv<span class="dt">(</span><span class="st">"rgb.csv"</span><span class="dt">)</span></span>
-<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>coloured = dataframe<span class="ch">[</span>COLOUR<span class="ch">]</span></span>
-<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a>print<span class="dt">(</span>coloured.means<span class="dt">())</span></span>
-<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a>=======</span>
-<span id="cb22-10"><a href="#cb22-10" aria-hidden="true" tabindex="-1"></a>COLUMN = <span class="st">"blue"</span></span>
-<span id="cb22-11"><a href="#cb22-11" aria-hidden="true" tabindex="-1"></a>dataframe = pd.read_csv<span class="dt">(</span><span class="st">"rgb.csv"</span><span class="dt">)</span></span>
-<span id="cb22-12"><a href="#cb22-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb22-13"><a href="#cb22-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb22-14"><a href="#cb22-14" aria-hidden="true" tabindex="-1"></a>subset = dataframe<span class="ch">[</span>COLUMN<span class="ch">]</span></span>
-<span id="cb22-15"><a href="#cb22-15" aria-hidden="true" tabindex="-1"></a>print<span class="dt">(</span>subset.means<span class="dt">())</span></span>
-<span id="cb22-16"><a href="#cb22-16" aria-hidden="true" tabindex="-1"></a>&gt;&gt;&gt;&gt;&gt;&gt;&gt; cde8d2ea9799a6ccbcfafabd311913cd3f70df17</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<p>Our change is preceded by <code>&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD</code>. Git has then inserted <code>=======</code> as a separator between the conflicting changes and marked the end of the content downloaded from GitHub with <code>&gt;&gt;&gt;&gt;&gt;&gt;&gt;</code>. (The string of letters and digits after that marker identifies the commit we’ve just downloaded.)</p>
-<p>It is now up to us to edit this file to remove these markers and reconcile the changes. We can do anything we want: keep the change made in the local repository, keep the change made in the remote repository, write something new to replace both, or get rid of the change entirely. Let’s replace both so that the file looks like this - we’ll keep Alice’s constant name <code>COLUMN</code> but change the default value back to red.</p>
 <div class="sourceCode" id="cb23"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cat mean.py</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <div class="sourceCode" id="cb24"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a>import pandas as pd</span>
-<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>COLUMN=<span class="st">"red"</span></span>
-<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>dataframe = pd.read_csv<span class="dt">(</span><span class="st">"rgb.csv"</span><span class="dt">)</span></span>
-<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>subset = dataframe<span class="ch">[</span>COLUMN<span class="ch">]</span></span>
-<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a>print<span class="dt">(</span>subset.means<span class="dt">())</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD</span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>COLOUR=<span class="st">"red"</span></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>dataframe = pd.read_csv<span class="dt">(</span><span class="st">"rgb.csv"</span><span class="dt">)</span></span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a>coloured = dataframe<span class="ch">[</span>COLOUR<span class="ch">]</span></span>
+<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a>print<span class="dt">(</span>coloured.means<span class="dt">())</span></span>
+<span id="cb24-9"><a href="#cb24-9" aria-hidden="true" tabindex="-1"></a>=======</span>
+<span id="cb24-10"><a href="#cb24-10" aria-hidden="true" tabindex="-1"></a>COLUMN = <span class="st">"blue"</span></span>
+<span id="cb24-11"><a href="#cb24-11" aria-hidden="true" tabindex="-1"></a>dataframe = pd.read_csv<span class="dt">(</span><span class="st">"rgb.csv"</span><span class="dt">)</span></span>
+<span id="cb24-12"><a href="#cb24-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-13"><a href="#cb24-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-14"><a href="#cb24-14" aria-hidden="true" tabindex="-1"></a>subset = dataframe<span class="ch">[</span>COLUMN<span class="ch">]</span></span>
+<span id="cb24-15"><a href="#cb24-15" aria-hidden="true" tabindex="-1"></a>print<span class="dt">(</span>subset.means<span class="dt">())</span></span>
+<span id="cb24-16"><a href="#cb24-16" aria-hidden="true" tabindex="-1"></a>&gt;&gt;&gt;&gt;&gt;&gt;&gt; cde8d2ea9799a6ccbcfafabd311913cd3f70df17</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>Our change is preceded by <code>&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD</code>. Git has then inserted <code>=======</code> as a separator between the conflicting changes and marked the end of the content downloaded from GitHub with <code>&gt;&gt;&gt;&gt;&gt;&gt;&gt;</code>. (The string of letters and digits after that marker identifies the commit we’ve just downloaded.)</p>
+<p>It is now up to us to edit this file to remove these markers and reconcile the changes. We can do anything we want: keep the change made in the local repository, keep the change made in the remote repository, write something new to replace both, or get rid of the change entirely. Let’s replace both so that the file looks like this - we’ll keep Alice’s constant name <code>COLUMN</code> but change the default value back to red.</p>
+<div class="sourceCode" id="cb25"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cat mean.py</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb26"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a>import pandas as pd</span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>COLUMN=<span class="st">"red"</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>dataframe = pd.read_csv<span class="dt">(</span><span class="st">"rgb.csv"</span><span class="dt">)</span></span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>subset = dataframe<span class="ch">[</span>COLUMN<span class="ch">]</span></span>
+<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>print<span class="dt">(</span>subset.means<span class="dt">())</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <p>To finish merging, we let git know that we’ve resolved the conflict by using <code>git add</code>.</p>
 <p>This always feels like an anticlimax to me - when I’ve resolved a conflict I feel like I should be able to say <code>git resolve</code> or <code>git peace-out</code> or something - but from git’s point of view, this resolution is just another set of changes to add to the staging area:</p>
-<div class="sourceCode" id="cb25"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> add mean.py</span>
-<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> status</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<div class="sourceCode" id="cb26"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a>On branch main</span>
-<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>All conflicts fixed but you are still merging.</span>
-<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">(</span>use <span class="st">"git commit"</span> to conclude merge<span class="dt">)</span></span>
-<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>Changes to be committed<span class="ch">:</span></span>
-<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a>    modified<span class="ch">:</span>   mean.py</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<div class="sourceCode" id="cb27"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> commit <span class="at">-m</span> <span class="st">"Merge changes from GitHub"</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<div class="sourceCode" id="cb28"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="ch">[main</span> 2abf2b1<span class="ch">]</span> Merge changes from GitHub</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb27"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> add mean.py</span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> status</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb28"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a>On branch main</span>
+<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a>All conflicts fixed but you are still merging.</span>
+<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">(</span>use <span class="st">"git commit"</span> to conclude merge<span class="dt">)</span></span>
+<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a>Changes to be committed<span class="ch">:</span></span>
+<span id="cb28-6"><a href="#cb28-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb28-7"><a href="#cb28-7" aria-hidden="true" tabindex="-1"></a>    modified<span class="ch">:</span>   mean.py</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb29"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> commit <span class="at">-m</span> <span class="st">"Merge changes from GitHub"</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb30"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="ch">[main</span> 2abf2b1<span class="ch">]</span> Merge changes from GitHub</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <p>Now Bob can push his changes to GitHub:</p>
-<div class="sourceCode" id="cb29"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> push origin main</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<div class="sourceCode" id="cb30"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a>Enumerating objects<span class="ch">:</span> 10, done.</span>
-<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>Counting objects<span class="ch">:</span> 100<span class="co">% (10/10), done.</span></span>
-<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>Delta compression using up to 12 threads</span>
-<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>Compressing objects<span class="ch">:</span> 100<span class="co">% (6/6), done.</span></span>
-<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>Writing objects<span class="ch">:</span> 100<span class="co">% (6/6), 709 bytes | 709.00 KiB/s, done.</span></span>
-<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a>Total 6 <span class="dt">(</span>delta 2<span class="dt">)</span>, reused 0 <span class="dt">(</span>delta 0<span class="dt">)</span>, pack-reused 0</span>
-<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Resolving deltas<span class="ch">:</span> 100<span class="co">% (2/2), completed with 2 local objects.</span></span>
-<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a>To github.com<span class="ch">:</span>alice/mean.git</span>
-<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a>   cde8d2e..19cb059  main -&gt; main</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb31"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> push origin main</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb32"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a>Enumerating objects<span class="ch">:</span> 10, done.</span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>Counting objects<span class="ch">:</span> 100<span class="co">% (10/10), done.</span></span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>Delta compression using up to 12 threads</span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a>Compressing objects<span class="ch">:</span> 100<span class="co">% (6/6), done.</span></span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a>Writing objects<span class="ch">:</span> 100<span class="co">% (6/6), 709 bytes | 709.00 KiB/s, done.</span></span>
+<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a>Total 6 <span class="dt">(</span>delta 2<span class="dt">)</span>, reused 0 <span class="dt">(</span>delta 0<span class="dt">)</span>, pack-reused 0</span>
+<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Resolving deltas<span class="ch">:</span> 100<span class="co">% (2/2), completed with 2 local objects.</span></span>
+<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a>To github.com<span class="ch">:</span>alice/mean.git</span>
+<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a>   cde8d2e..19cb059  main -&gt; main</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <p>Git keeps track of what we’ve merged with what, so we don’t have to fix things by hand again when Alice pulls again:</p>
-<div class="sourceCode" id="cb31"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> pull origin main</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<div class="sourceCode" id="cb32"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Enumerating objects<span class="ch">:</span> 10, done.</span>
-<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Counting objects<span class="ch">:</span> 100<span class="co">% (10/10), done.</span></span>
-<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Compressing objects<span class="ch">:</span> 100<span class="co">% (4/4), done.</span></span>
-<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Total 6 <span class="dt">(</span>delta 2<span class="dt">)</span>, reused 6 <span class="dt">(</span>delta 2<span class="dt">)</span>, pack-reused 0</span>
-<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a>Unpacking objects<span class="ch">:</span> 100<span class="co">% (6/6), 689 bytes | 137.00 KiB/s, done.</span></span>
-<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a>From github.com<span class="ch">:spikelynch/mean</span></span>
-<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a> * branch            main       -&gt; FETCH_HEAD</span>
-<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a>   cde8d2e..19cb059  main       -&gt; origin/main</span>
-<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a>Updating cde8d2e..19cb059</span>
-<span id="cb32-10"><a href="#cb32-10" aria-hidden="true" tabindex="-1"></a>Fast-forward</span>
-<span id="cb32-11"><a href="#cb32-11" aria-hidden="true" tabindex="-1"></a> mean.py <span class="ch">|</span> 4 ++--</span>
-<span id="cb32-12"><a href="#cb32-12" aria-hidden="true" tabindex="-1"></a> 1 file changed, 2 insertions<span class="dt">(</span>+<span class="dt">)</span>, 2 deletions<span class="dt">(</span>-<span class="dt">)</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb33"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> pull origin main</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb34"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Enumerating objects<span class="ch">:</span> 10, done.</span>
+<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Counting objects<span class="ch">:</span> 100<span class="co">% (10/10), done.</span></span>
+<span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Compressing objects<span class="ch">:</span> 100<span class="co">% (4/4), done.</span></span>
+<span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a>remote<span class="ch">:</span> Total 6 <span class="dt">(</span>delta 2<span class="dt">)</span>, reused 6 <span class="dt">(</span>delta 2<span class="dt">)</span>, pack-reused 0</span>
+<span id="cb34-5"><a href="#cb34-5" aria-hidden="true" tabindex="-1"></a>Unpacking objects<span class="ch">:</span> 100<span class="co">% (6/6), 689 bytes | 137.00 KiB/s, done.</span></span>
+<span id="cb34-6"><a href="#cb34-6" aria-hidden="true" tabindex="-1"></a>From github.com<span class="ch">:spikelynch/mean</span></span>
+<span id="cb34-7"><a href="#cb34-7" aria-hidden="true" tabindex="-1"></a> * branch            main       -&gt; FETCH_HEAD</span>
+<span id="cb34-8"><a href="#cb34-8" aria-hidden="true" tabindex="-1"></a>   cde8d2e..19cb059  main       -&gt; origin/main</span>
+<span id="cb34-9"><a href="#cb34-9" aria-hidden="true" tabindex="-1"></a>Updating cde8d2e..19cb059</span>
+<span id="cb34-10"><a href="#cb34-10" aria-hidden="true" tabindex="-1"></a>Fast-forward</span>
+<span id="cb34-11"><a href="#cb34-11" aria-hidden="true" tabindex="-1"></a> mean.py <span class="ch">|</span> 4 ++--</span>
+<span id="cb34-12"><a href="#cb34-12" aria-hidden="true" tabindex="-1"></a> 1 file changed, 2 insertions<span class="dt">(</span>+<span class="dt">)</span>, 2 deletions<span class="dt">(</span>-<span class="dt">)</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <p>We get the merged file:</p>
-<div class="sourceCode" id="cb33"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cat mean.py</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<div class="sourceCode" id="cb34"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a>import pandas as pd</span>
-<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a>COLUMN=<span class="st">"red"</span></span>
-<span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a>dataframe = pd.read_csv<span class="dt">(</span><span class="st">"rgb.csv"</span><span class="dt">)</span></span>
-<span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb34-5"><a href="#cb34-5" aria-hidden="true" tabindex="-1"></a>subset = dataframe<span class="ch">[</span>COLUMN<span class="ch">]</span></span>
-<span id="cb34-6"><a href="#cb34-6" aria-hidden="true" tabindex="-1"></a>print<span class="dt">(</span>subset.means<span class="dt">())</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb35"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cat mean.py</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<div class="sourceCode" id="cb36"><pre class="sourceCode abc code-with-copy"><code class="sourceCode abc"><span id="cb36-1"><a href="#cb36-1" aria-hidden="true" tabindex="-1"></a>import pandas as pd</span>
+<span id="cb36-2"><a href="#cb36-2" aria-hidden="true" tabindex="-1"></a>COLUMN=<span class="st">"red"</span></span>
+<span id="cb36-3"><a href="#cb36-3" aria-hidden="true" tabindex="-1"></a>dataframe = pd.read_csv<span class="dt">(</span><span class="st">"rgb.csv"</span><span class="dt">)</span></span>
+<span id="cb36-4"><a href="#cb36-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb36-5"><a href="#cb36-5" aria-hidden="true" tabindex="-1"></a>subset = dataframe<span class="ch">[</span>COLUMN<span class="ch">]</span></span>
+<span id="cb36-6"><a href="#cb36-6" aria-hidden="true" tabindex="-1"></a>print<span class="dt">(</span>subset.means<span class="dt">())</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 <p>We don’t need to merge again because Git knows someone has already done that.</p>
 <p>Git’s ability to resolve conflicts is very useful, but conflict resolution costs time and effort, and can introduce errors if conflicts are not resolved correctly. If you find yourself resolving a lot of conflicts in a project, consider these technical approaches to reducing them:</p>
 <ul>

--- a/docs/notebooks/12_conflicts.html
+++ b/docs/notebooks/12_conflicts.html
@@ -259,15 +259,6 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <li>Resolve conflicts from a merge</li>
 </ul>
 </section>
-<section id="key-points" class="level3 keypoints">
-<h3 class="anchored" data-anchor-id="key-points">Key Points</h3>
-<ul>
-<li>Conflicts occur when two or more people change the same lines of the same file.</li>
-<li>Git can emit a lot of warning messages when this happens</li>
-<li>There have been recent changes to how Git behaves when you pull updates from a remote</li>
-<li>The version control system does not allow people to overwrite each other’s changes blindly, but highlights conflicts so that they can be resolved.</li>
-</ul>
-</section>
 <p>We’ve shown an example of the sorts of changes which Git can merge automatically - where the changes are in separate parts of the file. But, as soon as people can work in parallel, they’ll likely step on each other’s toes.</p>
 <div class="quarto-figure quarto-figure-center">
 <figure class="figure">
@@ -522,6 +513,15 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <li>Discuss what order tasks should be carried out in with your collaborators so that tasks expected to change the same lines won’t be worked on simultaneously</li>
 <li>If the conflicts are stylistic churn (e.g.&nbsp;tabs vs.&nbsp;spaces), establish a project convention that is governing and use code style tools (e.g. <code>htmltidy</code>, <code>perltidy</code>, <code>rubocop</code>, etc.) to enforce, if necessary</li>
 </ul>
+<section id="key-points" class="level3 keypoints">
+<h3 class="anchored" data-anchor-id="key-points">Key Points</h3>
+<ul>
+<li>Conflicts occur when two or more people change the same lines of the same file.</li>
+<li>Git can emit a lot of warning messages when this happens</li>
+<li>There have been recent changes to how Git behaves when you pull updates from a remote</li>
+<li>The version control system does not allow people to overwrite each other’s changes blindly, but highlights conflicts so that they can be resolved.</li>
+</ul>
+</section>
 
 
 </section>

--- a/docs/notebooks/13_pull_requests.html
+++ b/docs/notebooks/13_pull_requests.html
@@ -258,13 +258,6 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <li>Understand how to contribute your changes back to theirs with a pull request</li>
 </ul>
 </section>
-<section id="key-points" class="level3 keypoints">
-<h3 class="anchored" data-anchor-id="key-points">Key Points</h3>
-<ul>
-<li>Forking allows you to create your own copy of an existing open-source project</li>
-<li>Pull requests are a way to offer your changes back to a project</li>
-</ul>
-</section>
 <p>We’ve just seen a branching workflow for allowing collaboration between a team of developers, each of whom has a local repo and who share a repo on GitHub.</p>
 <p>In this section, we’ll step through what’s called a fork-based workflow, which is a way to contribute code to another team’s project.</p>
 <p>We’ll do this exercise in pairs again, as we did for the first GitHub exercise, but this time we’ll imagine that Bob and Alice aren’t on the same team - instead, Bob wants to contribute a new feature to the <code>mean.py</code> script.</p>
@@ -377,6 +370,13 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p>Large open-source projects tend to have a lot of structure around pull requests: they will, for instance, provide a checklist of things contributors should do when contributing code: require that PRs be raised against an existing issue, provide a template for issues and/or PR comments, and so on.</p>
 <p>A pull request can be seen as the start of a collaboration between a developer and the maintainer - this can take the form of comments on the PR, or a more detailed kind of collaboration called a code review, which GitHub has a very good interface for - this allows a maintainer to add comments or questions to each individual change in a PR.</p>
 <p>This isn’t just used for open-source projects - many teams use pull requests and code review internally as an important form of quality control.</p>
+<section id="key-points" class="level3 keypoints">
+<h3 class="anchored" data-anchor-id="key-points">Key Points</h3>
+<ul>
+<li>Forking allows you to create your own copy of an existing open-source project</li>
+<li>Pull requests are a way to offer your changes back to a project</li>
+</ul>
+</section>
 
 
 </section>

--- a/docs/notebooks/14_open_research.html
+++ b/docs/notebooks/14_open_research.html
@@ -170,9 +170,11 @@ ul.task-list li input[type="checkbox"] {
   <ul class="collapse">
   <li><a href="#questions" id="toc-questions" class="nav-link" data-scroll-target="#questions">Questions</a></li>
   <li><a href="#objectives" id="toc-objectives" class="nav-link" data-scroll-target="#objectives">Objectives</a></li>
-  <li><a href="#key-points" id="toc-key-points" class="nav-link" data-scroll-target="#key-points">Key Points</a></li>
   <li><a href="#making-code-citable" id="toc-making-code-citable" class="nav-link" data-scroll-target="#making-code-citable">Making code citable</a></li>
-  <li><a href="#licensing-your-code" id="toc-licensing-your-code" class="nav-link" data-scroll-target="#licensing-your-code">Licensing your code</a></li>
+  <li><a href="#licensing-your-code" id="toc-licensing-your-code" class="nav-link" data-scroll-target="#licensing-your-code">Licensing your code</a>
+  <ul class="collapse">
+  <li><a href="#key-points" id="toc-key-points" class="nav-link" data-scroll-target="#key-points">Key Points</a></li>
+  </ul></li>
   </ul></li>
   </ul>
 </nav>
@@ -198,14 +200,6 @@ ul.task-list li input[type="checkbox"] {
 <li>Explain how a version control system can help with open science</li>
 <li>Explain how to provide a guide for people to be able to cite code</li>
 <li>Explain how to find guidance on the right license for your code</li>
-</ul>
-</section>
-<section id="key-points" class="level3 keypoints">
-<h3 class="anchored" data-anchor-id="key-points">Key Points</h3>
-<ul>
-<li>Open research is more useful and highly-cited than closed</li>
-<li>Adding a citation guide makes your work easier to cite</li>
-<li>There are a range of open-source licenses to suit different cases</li>
 </ul>
 </section>
 <pre class="quotation"><code>The opposite of "open" isn't "closed".
@@ -250,6 +244,14 @@ a remote server and replaces the file with a text pointer within the github repo
 Try downloading and installing the Git Large File Storage extension tool, then add 
 tracking of a large file to your github repository.  Ask a colleague to clone your
 repository and describe what they see when they access that large file.   </code></pre>
+<section id="key-points" class="level3 keypoints">
+<h3 class="anchored" data-anchor-id="key-points">Key Points</h3>
+<ul>
+<li>Open research is more useful and highly-cited than closed</li>
+<li>Adding a citation guide makes your work easier to cite</li>
+<li>There are a range of open-source licenses to suit different cases</li>
+</ul>
+</section>
 
 
 </section>

--- a/docs/setup.html
+++ b/docs/setup.html
@@ -236,7 +236,6 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
   <li><a href="#macos" id="toc-macos" class="nav-link" data-scroll-target="#macos">MacOS</a></li>
   <li><a href="#linux" id="toc-linux" class="nav-link" data-scroll-target="#linux">Linux</a></li>
   </ul></li>
-  <li><a href="#optional-install-gitkraken" id="toc-optional-install-gitkraken" class="nav-link" data-scroll-target="#optional-install-gitkraken">(Optional) Install GitKraken</a></li>
   </ul>
 </nav>
     </div>
@@ -368,18 +367,10 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <section id="openbsd" class="level5">
 <h5 class="anchored" data-anchor-id="openbsd">OpenBSD</h5>
 <div class="sourceCode" id="cb14"><pre class="sourceCode sh code-with-copy"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">pkg_add</span> git</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
-<hr>
-</section>
-</section>
-</section>
-<section id="optional-install-gitkraken" class="level2">
-<h2 class="anchored" data-anchor-id="optional-install-gitkraken">(Optional) Install GitKraken</h2>
-<ul>
-<li><p>We will show but not necessarily walk through <a href="https://www.gitkraken.com/">GitKraken</a>, an excellent (but paid for!) Git GUI tool. When working on large, multi-branch open-source and internal projects, this type of a tool can be very useful to navigate the mess that a too-many branch workflow can create.</p></li>
-<li><p><a href="https://desktop.github.com/">GitHub Desktop</a> is a free alternative developed by GitHub which you may want to use as a free GUI instead.</p></li>
-</ul>
 
 
+</section>
+</section>
 </section>
 
 <p>All materials copyright Sydney Informatics Hub, University of Sydney</p></main> <!-- /main -->

--- a/notebooks/01_intro.md
+++ b/notebooks/01_intro.md
@@ -16,15 +16,6 @@
 
 </div>  
 
-<div class="keypoints">
-
-### Key points
-
-- Version control is like an unlimited 'undo' (kind of, and not always)
-- Version control allows members of a team to work in parallel
-- Version control systems like GitHub are how people contribute to open source software
-
-</div>  
 
 ## What we'll cover in this workshop
 
@@ -103,3 +94,12 @@ These modern systems also include powerful merging tools that make it possible f
 
 The vast, vast majority of developers of both open-source and commercial software today use git as their version control system of choice - which is why we are teaching it in this course, and use it across all of our projects at SIH.
 
+<div class="keypoints">
+
+### Key points
+
+- Version control is like an unlimited 'undo' (kind of, and not always)
+- Version control allows members of a team to work in parallel
+- Version control systems like GitHub are how people contribute to open source software
+
+</div>  

--- a/notebooks/04_changes.md
+++ b/notebooks/04_changes.md
@@ -563,7 +563,7 @@ we first need to add the changed files to the staging area
 (`git add`) and then commit the staged changes to the
 repository (`git commit`):
 
-![The Git Commit Workflow](https://swcarpentry.github.io/git-novice/fig/git-committing.svg)
+![The Git Commit Workflow](../fig/git-committing.svg)
 
 
 <div class="challenge">

--- a/notebooks/07_github.md
+++ b/notebooks/07_github.md
@@ -26,8 +26,10 @@ Systems like Git allow us to move work between any two repositories.  In
 practice, though, it's easiest to use one copy as a central hub, and to keep it
 on the web rather than on someone's laptop.  Most programmers use hosting
 services like [GitHub](https://github.com), [Bitbucket](https://bitbucket.org) or
-[GitLab](https://gitlab.com/) to hold those main copies; we'll explore the pros
-and cons of this in a later episode.
+[GitLab](https://gitlab.com/) to hold those main copies. Your institution
+may also have its own hosted GitHub or GitLab instance. Where you host research
+software can depend on whether you want it to be public or private, and on
+what options are available to research staff or students.
 
 Let's start by sharing the changes we've made to our current project with the
 world. To this end we are going to create a *remote* repository that will be
@@ -89,8 +91,7 @@ Click on the 'SSH' link to change the protocol from HTTPS to SSH.
 
 We use SSH here because, while it requires some additional configuration, it is a 
 security protocol widely used by many applications.  The steps below describe SSH at a 
-minimum level for GitHub. A supplemental episode to this lesson discusses advanced setup 
-and concepts of SSH and key pairs, and other material supplemental to git related SSH. 
+minimum level for GitHub. 
 
 </div>  
 
@@ -148,15 +149,6 @@ and send git commands as my GitHub account.”
 
 What we will do now is the minimum required to set up the SSH keys and add the
 public key to a GitHub account.
-
-
-<div class="callout">  
-### Advanced SSH
-
-- A supplemental episode in this lesson discusses SSH and key pairs in more
-  depth and detail. 
-
-</div> 
 
 The first thing we are going to do is check if this has already been done on the
 computer you’re on.  Because generally speaking, this setup only needs to
@@ -315,8 +307,7 @@ our local repository to the repository on GitHub:
 git push origin main
 ```
 
-Since Alice set up a passphrase, it will prompt her for it.  If you completed advanced settings for your authentication, it 
-will not prompt for a passphrase. 
+Since Alice set up a passphrase, it will prompt her for it.
 
 ```abc
 Enumerating objects: 16, done.

--- a/notebooks/11_workflows.md
+++ b/notebooks/11_workflows.md
@@ -20,18 +20,6 @@
 
 </div>  
 
-
-<div class="keypoints">
-
-### Key Points
-
-- Creating a branch is a cheap, fast operation
-- Branch-based workflows are a good way for an individual or team to organise their repository
-- You can pick a naming convention which best suits your needs
-- Once a branch is merged, it can be safely deleted
-
-</div>
-
 We've just seen an example of creating a branch to do some development work, 
 and merging the changes back to the main branch.
 
@@ -190,3 +178,15 @@ If you are sure you want to delete it, run 'git branch -D just-testing'
 
 If we're sure that this branch isn't worth keeping, the capital `-D` flag 
 will get rid of it.
+
+
+<div class="keypoints">
+
+### Key Points
+
+- Creating a branch is a cheap, fast operation
+- Branch-based workflows are a good way for an individual or team to organise their repository
+- You can pick a naming convention which best suits your needs
+- Once a branch is merged, it can be safely deleted
+
+</div>

--- a/notebooks/12_conflicts.md
+++ b/notebooks/12_conflicts.md
@@ -154,8 +154,10 @@ Now we come to some exciting, or exasperating, developments: Git is an actively
 developed piece of open-source software. Over the last couple of years, there
 have been some changes to the way Git handles the situation we're about to
 trigger, and depending on when you installed Git, we might get some different
-sorts of behaviour at the command line. I'll have to go into a little bit of
-detail to explain what's happening, even though the net result will be the same.
+sorts of behaviour at the command line.
+
+I'll have to go into a little bit of detail to explain what's happening, even
+though the net result will be the same.
 
 What we're going to use is the `git pull` command. This asks Git to do two things:
 fetch the HEAD of the branch we're interested in from a remote repository, 
@@ -172,9 +174,8 @@ through the explanations.
 git pull origin main
 ```
 
-If Bob has a recent version of Git (newer than July, 2021), pulling from 
-Alice's remote should result in a long message like the following, ending
-in a fatal error:
+If Bob has a recent version of Git (2.33 or newer), pulling from Alice's remote
+should result in a long message like the following, ending in a fatal error:
 
 ```abc
 remote: Enumerating objects: 20, done.
@@ -267,13 +268,14 @@ CONFLICT (content): Merge conflict in mean.py
 Automatic merge failed; fix conflicts and then commit the result.
 ```
 
-This is the original (pre-2020) `git pull` behaviour, when it used to merge
-by default. If this happened to you, git has fetched Alice's copy and tried,
-and failed, to merge it with the local changes
+This is how `git pull` behaved before version 2.27, when it used to merge by
+default and not warn you about it. If this happened to you, git has fetched
+Alice's copy and tried, and failed, to merge it with the local changes.
 
-The third possibility is for people with a copy of Git from 2020 to 2021: this
-gives the long set of warnings about needing to specify a reconciliation
-strategy, but defaults to `merge` anyway, and should look something like this:
+The third possibility is for people with a copy of Git with a version between
+2.27 and 2.33: this gives the long set of warnings about needing to specify a
+reconciliation strategy, but defaults to `merge` anyway, and should look
+something like this:
 
 ```abc
 remote: Enumerating objects: 20, done.
@@ -299,6 +301,16 @@ hint: invocation.
 Auto-merging mean.py
 CONFLICT (content): Merge conflict in mean.py
 Automatic merge failed; fix conflicts and then commit the result.
+```
+
+You can check which version of Git you have installed by running this command:
+
+```sh
+git --version
+```
+
+```abc
+git version 2.37.0 (Apple Git-136)
 ```
 
 Let's just go around the room and check that everyone has a big CAPS-LOCK

--- a/notebooks/12_conflicts.md
+++ b/notebooks/12_conflicts.md
@@ -19,15 +19,6 @@
 </div>  
 
 
-<div class="keypoints">
-
-### Key Points
-
-- Conflicts occur when two or more people change the same lines of the same file.
-- Git can emit a lot of warning messages when this happens
-- There have been recent changes to how Git behaves when you pull updates from a remote
-- The version control system does not allow people to overwrite each other's changes blindly, but highlights conflicts so that they can be resolved.
-</div>
 
 We've shown an example of the sorts of changes which Git can merge
 automatically - where the changes are in separate parts of the file. But, as
@@ -481,3 +472,12 @@ Conflicts can also be minimized with project management strategies:
   project convention that is governing and use code style tools (e.g.
   `htmltidy`, `perltidy`, `rubocop`, etc.) to enforce, if necessary
 
+<div class="keypoints">
+
+### Key Points
+
+- Conflicts occur when two or more people change the same lines of the same file.
+- Git can emit a lot of warning messages when this happens
+- There have been recent changes to how Git behaves when you pull updates from a remote
+- The version control system does not allow people to overwrite each other's changes blindly, but highlights conflicts so that they can be resolved.
+</div>

--- a/notebooks/13_pull_requests.md
+++ b/notebooks/13_pull_requests.md
@@ -18,14 +18,6 @@
 </div>  
 
 
-<div class="keypoints">
-
-### Key Points
-
-- Forking allows you to create your own copy of an existing open-source project
-- Pull requests are a way to offer your changes back to a project
-
-</div>
 
 We've just seen a branching workflow for allowing collaboration between a team
 of developers, each of whom has a local repo and who share a repo on GitHub.
@@ -221,3 +213,12 @@ each individual change in a PR.
 
 This isn't just used for open-source projects - many teams use pull requests
 and code review internally as an important form of quality control.
+
+<div class="keypoints">
+
+### Key Points
+
+- Forking allows you to create your own copy of an existing open-source project
+- Pull requests are a way to offer your changes back to a project
+
+</div>

--- a/notebooks/14_open_research.md
+++ b/notebooks/14_open_research.md
@@ -21,16 +21,6 @@
 </div>  
 
 
-<div class="keypoints">
-
-### Key Points
-
-- Open research is more useful and highly-cited than closed
-- Adding a citation guide makes your work easier to cite
-- There are a range of open-source licenses to suit different cases
-
-</div>
-
 ```quotation
 The opposite of "open" isn't "closed".
 The opposite of "open" is "broken".
@@ -115,3 +105,14 @@ Try downloading and installing the Git Large File Storage extension tool, then a
 tracking of a large file to your github repository.  Ask a colleague to clone your
 repository and describe what they see when they access that large file.   
 ```
+
+<div class="keypoints">
+
+### Key Points
+
+- Open research is more useful and highly-cited than closed
+- Adding a citation guide makes your work easier to cite
+- There are a range of open-source licenses to suit different cases
+
+</div>
+


### PR DESCRIPTION
a section later on that I removed, mentioned institutional git
repos, and took out references to the "advanced ssh" section which
the Carpentries material mentions, but which isn't there either